### PR TITLE
fix: Initialize typed properties with default values

### DIFF
--- a/src/Batch/Batch.php
+++ b/src/Batch/Batch.php
@@ -52,11 +52,11 @@ class Batch
 
     protected Application $application;
 
-    protected ?Exception $lastException;
+    protected ?Exception $lastException = null;
 
     protected ReturnCodeStack $returnCodeStack;
 
-    protected bool $hasRun;
+    protected bool $hasRun = false;
 
     /**
      * Batch constructor.

--- a/tests/Unit/Batch/BatchTest.php
+++ b/tests/Unit/Batch/BatchTest.php
@@ -316,4 +316,22 @@ HD;
 
         $this->assertEquals('Hello FooOops.', $this->getOutput());
     }
+
+    public function testHasExceptionReturnsFalseBeforeRun(): void
+    {
+        $sut = new Batch($this->app, $this->output);
+
+        $this->assertFalse($sut->hasException());
+        $this->assertNull($sut->getLastException());
+    }
+
+    public function testHasExceptionReturnsFalseAfterSuccessfulRun(): void
+    {
+        $sut = new Batch($this->app, $this->output);
+        $sut->addMessage('test');
+        $sut->run();
+
+        $this->assertFalse($sut->hasException());
+        $this->assertNull($sut->getLastException());
+    }
 }


### PR DESCRIPTION
## Summary

Typed properties `$lastException` and `$hasRun` in the Batch class were declared without default values, causing "must not be accessed before initialization" errors in PHP 8.x when `hasException()` or similar methods were called before the properties were set.

This fixes #35 

## Changes

- Initialize `$lastException` to `null`
- Initialize `$hasRun` to `false`

## Problem

When using `Batch::create()->add(...)->run()` followed by `hasException()`, PHP throws:

```
Typed property EFrane\ConsoleAdditions\Batch\Batch::$lastException must not be accessed before initialization
```

This happens because `hasException()` checks `$this->lastException instanceof Exception` but the property was never initialized.

## Solution

Add default values to the typed property declarations:

```php
protected ?Exception $lastException = null;
protected bool $hasRun = false;
```